### PR TITLE
Feature/tests verbose

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Initialize autoconf
-AC_INIT([cserio], [1.3.0])
+AC_INIT([cserio], [1.3.1])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_PREFIX_DEFAULT([..])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])

--- a/src/cserio.h
+++ b/src/cserio.h
@@ -24,8 +24,8 @@
  * For now, ensure that the version defined here matches
  * that one defined in the `configure.ac` file.
  */
-#define CSERIO_VERSION 1.3.0
-#define CSERIO_MICRO 0
+#define CSERIO_VERSION 1.3.1
+#define CSERIO_MICRO 1
 #define CSERIO_MINOR 3
 #define CSERIO_MAJOR 1
 

--- a/tests/test_core_routines.c
+++ b/tests/test_core_routines.c
@@ -142,8 +142,9 @@ void test_ser_file_close() {
 
 /*-------------------- Main Test Call --------------------*/
 
-void run_core_routines_suite() {
+void run_core_routines_suite(int is_verbose) {
   printf("!-- RUNNING CORE ROUTINES SUITE --!\n");
+  IS_VERBOSE = is_verbose;
 
   test_ser_file_open();
   test_ser_file_close();

--- a/tests/test_header_routines.c
+++ b/tests/test_header_routines.c
@@ -328,8 +328,9 @@ void test_ser_get_key_record() {
 
 /*-------------------- Main Test Call --------------------*/
 
-void run_header_routines_suite() {
+void run_header_routines_suite(int is_verbose) {
   printf("!-- RUNNING HEADER ROUTINES SUITE --!\n");
+  IS_VERBOSE = is_verbose;
 
   test_ser_get_hdr_count();
   test_ser_get_idx_record();

--- a/tests/test_img_routines.c
+++ b/tests/test_img_routines.c
@@ -323,9 +323,10 @@ void test_ser_read_frame(serfile* sptr, FileHeader* file_header, void* pix_buff)
 
 /*-------------------- Main Test Call --------------------*/
 
-void run_img_routines_suite() {
+void run_img_routines_suite(int is_verbose) {
   printf("!-- RUNNING IMAGE ROUTINES SUITE --!\n");
-  
+  IS_VERBOSE = is_verbose;
+
   /* sequentially shared data */
   FileHeader temp_header;
   int status = 0;

--- a/tests/test_routines.h
+++ b/tests/test_routines.h
@@ -7,8 +7,10 @@
 #ifndef TEST_CORE_ROUTINES_H
 #define TEST_CORE_ROUTINES_H
 
-void run_core_routines_suite();
-void run_header_routines_suite();
-void run_img_routines_suite();
+static int IS_VERBOSE = 0;
+
+void run_core_routines_suite(int is_verbose);
+void run_header_routines_suite(int is_verbose);
+void run_img_routines_suite(int is_verbose);
 
 #endif

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -27,8 +27,9 @@
  *  @param  line      (I) - line number of error
  *  @return Void.
  */
-void check_error_v(int status, int target, char* file, int line) {
+void check_error_v(int status, int target, char* file, int line, int is_verbose) {
   if (status == target) {
+    if (!is_verbose) return;
     printf("!CHECK STATUS SUCCESS! IN FILE %s ON LINE %4d: %4d == %4d\n", file, line, status, target);
   } else {
     printf("!CHECK STATUS FAILED!\n");
@@ -47,8 +48,9 @@ void check_error_v(int status, int target, char* file, int line) {
  *  @param  line      (I) - line number of error
  *  @return Void.
  */
-void check_buff_v(void* result, void* target, unsigned long byte_len, char* file, int line) {
+void check_buff_v(void* result, void* target, unsigned long byte_len, char* file, int line, int is_verbose) {
   if (!memcmp(result, target, byte_len)) {
+    if (!is_verbose) return;
     printf("!CHECK BUFFERS SUCCESS! IN FILE %s ON LINE %4d\n", file, line);
   } else {
     printf("!CHECK BUFF FAILED!\n");
@@ -66,8 +68,9 @@ void check_buff_v(void* result, void* target, unsigned long byte_len, char* file
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_int_v(int result, int target, char* file, int line) {
+void check_int_v(int result, int target, char* file, int line, int is_verbose) {
   if (result == target) {
+    if (!is_verbose) return;
     printf("!CHECK INTEGERS SUCCESS! IN FILE %s ON LINE %4d: %4d == %4d\n", file, line, result, target);
   } else {
     printf("!CHECK INTEGERS FAILED!\n");
@@ -85,8 +88,9 @@ void check_int_v(int result, int target, char* file, int line) {
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_unsigned_long_v(unsigned long result, unsigned long target, char* file, int line) {
+void check_unsigned_long_v(unsigned long result, unsigned long target, char* file, int line, int is_verbose) {
   if (result == target) {
+    if (!is_verbose) return;
     printf("!CHECK U-LONG SUCCESS! IN FILE %s ON LINE %4d: %4lu == %4lu\n", file, line, result, target);
   } else {
     printf("!CHECK ULONG FAILED!\n");

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -25,8 +25,8 @@
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_error_v(int status, int target, char* file, int line);
-#define check_error(status, target) check_error_v(status, target, __FILE__, __LINE__)
+void check_error_v(int status, int target, char* file, int line, int is_verbose);
+#define check_error(status, target) check_error_v(status, target, __FILE__, __LINE__, IS_VERBOSE)
 
 /** @brief  Check if the result and target buffers are equal
  *
@@ -40,8 +40,8 @@ void check_error_v(int status, int target, char* file, int line);
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_buff_v(void* result, void* target, unsigned long byte_len, char* file, int line);
-#define check_buff(result, target, byte_len) check_buff_v(result, target, byte_len, __FILE__, __LINE__)
+void check_buff_v(void* result, void* target, unsigned long byte_len, char* file, int line, int is_verbose);
+#define check_buff(result, target, byte_len) check_buff_v(result, target, byte_len, __FILE__, __LINE__, IS_VERBOSE)
 
 /** @brief  Check if the result and target integers are equal
  *
@@ -51,8 +51,8 @@ void check_buff_v(void* result, void* target, unsigned long byte_len, char* file
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_int_v(int result, int target, char* file, int line);
-#define check_int(result, target) check_int_v(result, target, __FILE__, __LINE__)
+void check_int_v(int result, int target, char* file, int line, int is_verbose);
+#define check_int(result, target) check_int_v(result, target, __FILE__, __LINE__, IS_VERBOSE)
 
 /** @brief  Check if the result and target unsigned longs are equal
  *
@@ -62,8 +62,8 @@ void check_int_v(int result, int target, char* file, int line);
  *  @param  line      (I) - line number of error.
  *  @return Void.
  */
-void check_unsigned_long_v(unsigned long result, unsigned long target, char* file, int line);
-#define check_unsigned_long(result, target) check_unsigned_long_v(result, target, __FILE__, __LINE__)
+void check_unsigned_long_v(unsigned long result, unsigned long target, char* file, int line, int is_verbose);
+#define check_unsigned_long(result, target) check_unsigned_long_v(result, target, __FILE__, __LINE__, IS_VERBOSE)
 
 
 

--- a/tests/tests_main.c
+++ b/tests/tests_main.c
@@ -6,13 +6,24 @@
 
 #include "test_routines.h"
 
+#include <string.h>
+
 /*-------------------- Main --------------------*/
 
 int main(int argc, char* argv[]) {
+  int is_verbose = 0;
 
-  run_core_routines_suite();
-  run_header_routines_suite();
-  run_img_routines_suite();
+  /* check for verbose flag */
+  if (argc > 1) {
+    char* flag = argv[1];
+    if (!strncmp(flag, "-v", 2)) {
+      is_verbose= 1;
+    }
+  }
+
+  run_core_routines_suite(is_verbose);
+  run_header_routines_suite(is_verbose);
+  run_img_routines_suite(is_verbose);
 
   return 0;
 }


### PR DESCRIPTION
Running `./test-runner` with a `-v` flag, like `./test-runner -v`, will flag the testing program to print verbose output. Otherwise, the test runner only prints errors.